### PR TITLE
fix: disable force_ssl for reverse proxy deployments

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -7,15 +7,16 @@ import Config
 # before starting your production server.
 config :viche, VicheWeb.Endpoint, cache_static_manifest: "priv/static/cache_manifest.json"
 
-# Force using SSL in production. This also sets the "strict-security-transport" header,
-# known as HSTS. If you have a health check endpoint, you may want to exclude it below.
-# Note `:force_ssl` is required to be set at compile-time.
-config :viche, VicheWeb.Endpoint,
-  force_ssl: [rewrite_on: [:x_forwarded_proto]],
-  exclude: [
-    # paths: ["/health"],
-    hosts: ["localhost", "127.0.0.1"]
-  ]
+# force_ssl is disabled — TLS is terminated by the reverse proxy (e.g. Traefik).
+# Enabling force_ssl when behind a proxy breaks internal Docker network WebSocket
+# connections (Phoenix redirects HTTP→HTTPS before the WS upgrade can complete).
+# If running without a reverse proxy, uncomment the block below:
+#
+# config :viche, VicheWeb.Endpoint,
+#   force_ssl: [rewrite_on: [:x_forwarded_proto]],
+#   exclude: [
+#     hosts: ["localhost", "127.0.0.1"]
+#   ]
 
 # Configure Swoosh API Client
 config :swoosh, api_client: Swoosh.ApiClient.Req


### PR DESCRIPTION
## Summary
- Disables `force_ssl` in `prod.exs` to support deployments behind TLS-terminating reverse proxies (e.g. Traefik, nginx)
- When `force_ssl` is enabled, Phoenix redirects internal HTTP requests to HTTPS before WebSocket upgrades can complete, breaking agent-to-agent WebSocket connections on the same Docker network
- The original config is preserved as a commented block for users running without a reverse proxy

## Context
When deploying Viche behind Traefik (Docker Compose), the OpenClaw Viche plugin connects via internal Docker DNS (`http://viche:4000`). Phoenix's `force_ssl` middleware sees the plain HTTP request and returns a 301 redirect to HTTPS, which the Phoenix Channel WebSocket client cannot follow. This makes the WebSocket connection fail in a reconnect loop.

## Test plan
- [ ] Verify WebSocket connections work from internal Docker network without `X-Forwarded-Proto` header
- [ ] Verify external HTTPS access still works through Traefik
- [ ] Verify `/.well-known/agent-registry` is accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)