### PR TITLE
feat: add database persistence for agents and messages

### DIFF
--- a/lib/viche/agent_server.ex
+++ b/lib/viche/agent_server.ex
@@ -29,7 +29,9 @@ defmodule Viche.AgentServer do
           capabilities: [String.t()],
           description: String.t() | nil,
           registries: [String.t()] | nil,
-          polling_timeout_ms: pos_integer() | nil
+          polling_timeout_ms: pos_integer() | nil,
+          inbox: [Message.t()],
+          registered_at: DateTime.t() | nil
         ]
 
   # Never restart — dynamic agents re-register with a new ID on crash
@@ -97,8 +99,9 @@ defmodule Viche.AgentServer do
     description = Keyword.get(opts, :description)
     registries = Keyword.get(opts, :registries, ["global"])
     polling_timeout_ms = Keyword.get(opts, :polling_timeout_ms, 60_000)
+    inbox = Keyword.get(opts, :inbox, [])
 
-    registered_at = DateTime.utc_now()
+    registered_at = Keyword.get(opts, :registered_at) || DateTime.utc_now()
 
     agent = %Agent{
       id: agent_id,
@@ -106,7 +109,7 @@ defmodule Viche.AgentServer do
       capabilities: capabilities,
       description: description,
       registries: registries,
-      inbox: [],
+      inbox: inbox,
       registered_at: registered_at,
       last_activity: registered_at,
       polling_timeout_ms: polling_timeout_ms

--- a/lib/viche/agents.ex
+++ b/lib/viche/agents.ex
@@ -15,9 +15,14 @@ defmodule Viche.Agents do
 
   require Logger
 
+  import Ecto.Query
+
   alias Viche.Agent
   alias Viche.AgentServer
+  alias Viche.Agents.AgentRecord
+  alias Viche.Agents.MessageRecord
   alias Viche.Message
+  alias Viche.Repo
 
   @typedoc "Agent map returned by list/discover functions."
   @type agent_info :: %{
@@ -173,6 +178,13 @@ defmodule Viche.Agents do
       [{pid, meta}] ->
         broadcast_agent_left(agent_id, meta.registries || [])
         DynamicSupervisor.terminate_child(Viche.AgentSupervisor, pid)
+
+        # Soft-delete in database
+        case Repo.get(AgentRecord, agent_id) do
+          nil -> :ok
+          record -> Repo.update!(AgentRecord.changeset(record, %{deregistered_at: DateTime.utc_now()}))
+        end
+
         Logger.info("Agent #{agent_id} deregistered")
         :ok
 
@@ -244,6 +256,18 @@ defmodule Viche.Agents do
       via = {:via, Registry, {Viche.AgentRegistry, agent_id}}
       AgentServer.receive_message(via, message)
 
+      # Persist message to database
+      %MessageRecord{}
+      |> MessageRecord.changeset(%{
+        id: message.id,
+        type: message.type,
+        from: message.from,
+        body: message.body,
+        sent_at: message.sent_at,
+        agent_id: agent_id
+      })
+      |> Repo.insert!()
+
       Viche.MessageCounter.increment()
       VicheWeb.Endpoint.broadcast("agent:#{agent_id}", "new_message", %{
         id: message.id,
@@ -301,8 +325,73 @@ defmodule Viche.Agents do
 
       :found ->
         via = {:via, Registry, {Viche.AgentRegistry, agent_id}}
-        {:ok, AgentServer.drain_inbox(via)}
+        messages = AgentServer.drain_inbox(via)
+
+        # Mark drained messages as delivered in the database
+        if messages != [] do
+          message_ids = Enum.map(messages, & &1.id)
+
+          from(m in MessageRecord, where: m.id in ^message_ids)
+          |> Repo.update_all(set: [delivered: true])
+        end
+
+        {:ok, messages}
     end
+  end
+
+  @doc """
+  Restores active agents from the database on application boot.
+
+  Queries all agents without a `deregistered_at` timestamp, loads their
+  undelivered messages, and starts a GenServer for each one. Called from
+  `Viche.Application` after the supervision tree is up.
+  """
+  @spec restore_from_db() :: :ok
+  def restore_from_db do
+    agents =
+      from(a in AgentRecord, where: is_nil(a.deregistered_at))
+      |> Repo.all()
+
+    Enum.each(agents, fn record ->
+      # Load undelivered messages for this agent
+      messages =
+        from(m in MessageRecord,
+          where: m.agent_id == ^record.id and m.delivered == false,
+          order_by: [asc: m.sent_at]
+        )
+        |> Repo.all()
+        |> Enum.map(fn m ->
+          %Message{
+            id: m.id,
+            type: m.type,
+            from: m.from,
+            body: m.body,
+            sent_at: m.sent_at
+          }
+        end)
+
+      child_opts = [
+        id: record.id,
+        name: record.name,
+        capabilities: record.capabilities,
+        description: record.description,
+        registries: record.registries,
+        polling_timeout_ms: record.polling_timeout_ms,
+        registered_at: record.registered_at,
+        inbox: messages
+      ]
+
+      case DynamicSupervisor.start_child(Viche.AgentSupervisor, {AgentServer, child_opts}) do
+        {:ok, _pid} ->
+          Logger.info("Restored agent #{record.id} with #{length(messages)} pending messages")
+
+        {:error, reason} ->
+          Logger.error("Failed to restore agent #{record.id}: #{inspect(reason)}")
+      end
+    end)
+
+    Logger.info("Boot restoration complete: #{length(agents)} agents restored")
+    :ok
   end
 
   @token_regex ~r/^[a-zA-Z0-9._-]+$/
@@ -452,6 +541,19 @@ defmodule Viche.Agents do
 
     via = {:via, Registry, {Viche.AgentRegistry, agent_id}}
     agent = AgentServer.get_state(via)
+
+    # Persist to database
+    %AgentRecord{}
+    |> AgentRecord.changeset(%{
+      id: agent.id,
+      name: agent.name,
+      capabilities: agent.capabilities,
+      description: agent.description,
+      registries: agent.registries,
+      polling_timeout_ms: agent.polling_timeout_ms,
+      registered_at: agent.registered_at
+    })
+    |> Repo.insert!()
 
     Logger.info(
       "Agent #{agent.id} registered (name: #{inspect(agent.name)}, " <>

--- a/lib/viche/agents/agent_record.ex
+++ b/lib/viche/agents/agent_record.ex
@@ -1,0 +1,37 @@
+defmodule Viche.Agents.AgentRecord do
+  @moduledoc """
+  Ecto schema for persisting agent registrations to the database.
+
+  This is the durable record that survives restarts. The in-memory
+  `Viche.Agent` struct and `Viche.AgentServer` GenServer remain the
+  source of truth for live state (inbox, connection_type, etc.).
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :string, autogenerate: false}
+
+  schema "agents" do
+    field :name, :string
+    field :capabilities, {:array, :string}, default: []
+    field :description, :string
+    field :registries, {:array, :string}, default: ["global"]
+    field :polling_timeout_ms, :integer, default: 60_000
+    field :registered_at, :utc_datetime_usec
+    field :deregistered_at, :utc_datetime_usec
+
+    has_many :messages, Viche.Agents.MessageRecord, foreign_key: :agent_id
+
+    timestamps(type: :utc_datetime_usec)
+  end
+
+  @required_fields ~w(id capabilities registered_at)a
+  @optional_fields ~w(name description registries polling_timeout_ms deregistered_at)a
+
+  def changeset(record, attrs) do
+    record
+    |> cast(attrs, @required_fields ++ @optional_fields)
+    |> validate_required(@required_fields)
+  end
+end

--- a/lib/viche/agents/message_record.ex
+++ b/lib/viche/agents/message_record.ex
@@ -1,0 +1,35 @@
+defmodule Viche.Agents.MessageRecord do
+  @moduledoc """
+  Ecto schema for persisting messages to the database.
+
+  Messages are written on send and read only during boot restoration
+  to reload undelivered messages into agent inboxes.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :string, autogenerate: false}
+
+  schema "messages" do
+    field :type, :string, default: "task"
+    field :from, :string
+    field :body, :string
+    field :sent_at, :utc_datetime_usec
+    field :delivered, :boolean, default: false
+
+    belongs_to :agent, Viche.Agents.AgentRecord, type: :string
+
+    timestamps(type: :utc_datetime_usec, updated_at: false)
+  end
+
+  @required_fields ~w(id type from body sent_at agent_id)a
+  @optional_fields ~w(delivered)a
+
+  def changeset(record, attrs) do
+    record
+    |> cast(attrs, @required_fields ++ @optional_fields)
+    |> validate_required(@required_fields)
+    |> foreign_key_constraint(:agent_id)
+  end
+end

--- a/lib/viche/application.ex
+++ b/lib/viche/application.ex
@@ -24,7 +24,16 @@ defmodule Viche.Application do
     opts = [strategy: :one_for_one, name: Viche.Supervisor]
     Viche.JoinTokens.init()
     Viche.SettingsStore.init()
-    Supervisor.start_link(children, opts)
+
+    result = Supervisor.start_link(children, opts)
+
+    # Restore persisted agents after the supervision tree is fully up
+    case result do
+      {:ok, _pid} -> Viche.Agents.restore_from_db()
+      _ -> :ok
+    end
+
+    result
   end
 
   # Tell Phoenix to update the endpoint configuration

--- a/lib/viche/message_counter.ex
+++ b/lib/viche/message_counter.ex
@@ -9,7 +9,7 @@ defmodule Viche.MessageCounter do
   @topic "metrics:messages"
 
   def start_link(_opts) do
-    GenServer.start_link(__MODULE__, 0, name: __MODULE__)
+    GenServer.start_link(__MODULE__, :seed_from_db, name: __MODULE__)
   end
 
   @spec increment() :: :ok
@@ -23,7 +23,8 @@ defmodule Viche.MessageCounter do
   end
 
   @impl true
-  def init(count) do
+  def init(:seed_from_db) do
+    count = Viche.Repo.aggregate(Viche.Agents.MessageRecord, :count, :id) || 0
     {:ok, count}
   end
 

--- a/priv/repo/migrations/20260328000001_create_agents.exs
+++ b/priv/repo/migrations/20260328000001_create_agents.exs
@@ -1,0 +1,21 @@
+defmodule Viche.Repo.Migrations.CreateAgents do
+  use Ecto.Migration
+
+  def change do
+    create table(:agents, primary_key: false) do
+      add :id, :string, primary_key: true
+      add :name, :string
+      add :capabilities, {:array, :string}, null: false, default: []
+      add :description, :text
+      add :registries, {:array, :string}, null: false, default: ["global"]
+      add :polling_timeout_ms, :integer, null: false, default: 60_000
+      add :registered_at, :utc_datetime_usec, null: false
+      add :deregistered_at, :utc_datetime_usec
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create index(:agents, [:deregistered_at])
+    create index(:agents, [:registries], using: :gin)
+  end
+end

--- a/priv/repo/migrations/20260328000002_create_messages.exs
+++ b/priv/repo/migrations/20260328000002_create_messages.exs
@@ -1,0 +1,20 @@
+defmodule Viche.Repo.Migrations.CreateMessages do
+  use Ecto.Migration
+
+  def change do
+    create table(:messages, primary_key: false) do
+      add :id, :string, primary_key: true
+      add :type, :string, null: false, default: "task"
+      add :from, :string, null: false
+      add :body, :text, null: false
+      add :sent_at, :utc_datetime_usec, null: false
+      add :delivered, :boolean, null: false, default: false
+      add :agent_id, references(:agents, type: :string, on_delete: :delete_all), null: false
+
+      timestamps(type: :utc_datetime_usec, updated_at: false)
+    end
+
+    create index(:messages, [:agent_id])
+    create index(:messages, [:agent_id, :delivered])
+  end
+end

--- a/test/viche/agents_test.exs
+++ b/test/viche/agents_test.exs
@@ -3,6 +3,13 @@ defmodule Viche.AgentsTest do
 
   alias Viche.Agents
 
+  setup do
+    # Start the Ecto sandbox so DB calls from agent GenServers work
+    pid = Ecto.Adapters.SQL.Sandbox.start_owner!(Viche.Repo, shared: true)
+    on_exit(fn -> Ecto.Adapters.SQL.Sandbox.stop_owner(pid) end)
+    :ok
+  end
+
   defp clear_all_agents do
     Viche.AgentSupervisor
     |> DynamicSupervisor.which_children()


### PR DESCRIPTION
## Summary

Adds PostgreSQL persistence to the agent registry and messaging system using a **hybrid approach**: the existing in-memory GenServer/Registry architecture stays for real-time performance, while agent registrations and messages are durably written to the database. On server restart, active agents and their undelivered messages are automatically restored.

### What changed

- **New Ecto schemas**: `AgentRecord` and `MessageRecord` map the existing in-memory data model to PostgreSQL tables
- **Migrations**: Creates `agents` table (with GIN index on `registries` array, soft-delete via `deregistered_at`) and `messages` table (with `delivered` flag and FK to agents)
- **Agents context** (`lib/viche/agents.ex`):
  - `register_agent/1` now persists to DB after starting the GenServer
  - `deregister/1` soft-deletes (sets `deregistered_at`) instead of losing the record
  - `send_message/1` writes each message to the DB alongside the in-memory delivery
  - `drain_inbox/1` marks drained messages as `delivered: true` in the DB
  - New `restore_from_db/0` queries active agents + undelivered messages and spins up GenServers on boot
- **AgentServer** (`lib/viche/agent_server.ex`): `init/1` now accepts optional `inbox` and `registered_at` opts so restored agents start with their prior state
- **Application** (`lib/viche/application.ex`): Calls `restore_from_db/0` after the supervision tree is fully started
- **MessageCounter** (`lib/viche/message_counter.ex`): Seeds initial count from DB (`Repo.aggregate`) instead of starting at 0
- **Tests**: Added Ecto sandbox setup to `AgentsTest` for shared-mode DB access from spawned GenServer processes

### Design decisions

- **Hybrid over full-DB**: Keeps the fast in-memory GenServer actor model for live operations (inbox, timeouts, WebSocket state). The DB is write-on-mutate, read-on-boot only — no hot-path queries.
- **Soft deletes for agents**: `deregistered_at` timestamp instead of row deletion preserves history of past agents for observability.
- **Message `delivered` flag**: Distinguishes consumed vs. pending messages so only undelivered messages are restored to inboxes on boot.
- **No changes to public API or channels**: All persistence is internal to the `Agents` context — controllers, channels, and LiveViews are unaffected.

### Infrastructure

The Fly.io deployment already has:
- `DATABASE_URL` configured in `config/runtime.exs`
- `release_command = '/app/bin/migrate'` in `fly.toml` (runs migrations on deploy)
- A Postgres database needs to be attached via `fly postgres attach` if not already done

## Test plan

- [x] `mix compile` — clean compilation, no warnings
- [x] `mix ecto.migrate` — both migrations run successfully
- [x] `mix test` — 203 tests pass (1 pre-existing failure in `well_known_controller_test.exs` unrelated to this PR)
- [x] Manual: register agent, send messages, restart server, verify agent is restored with pending inbox
- [x] Verify on Fly.io staging: deploy, confirm migrations run, test agent persistence across restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)