### PR TITLE
feat(connections): longer grace period + heartbeat endpoint (#22)

### DIFF
--- a/lib/viche/agent.ex
+++ b/lib/viche/agent.ex
@@ -18,7 +18,8 @@ defmodule Viche.Agent do
           registered_at: DateTime.t(),
           connection_type: connection_type(),
           last_activity: DateTime.t() | nil,
-          polling_timeout_ms: pos_integer()
+          polling_timeout_ms: pos_integer(),
+          grace_period_ms: pos_integer() | nil
         }
 
   @default_polling_timeout_ms 60_000
@@ -33,6 +34,7 @@ defmodule Viche.Agent do
     inbox: [],
     connection_type: :long_poll,
     last_activity: nil,
-    polling_timeout_ms: @default_polling_timeout_ms
+    polling_timeout_ms: @default_polling_timeout_ms,
+    grace_period_ms: nil
   ]
 end

--- a/lib/viche/agent_server.ex
+++ b/lib/viche/agent_server.ex
@@ -29,7 +29,8 @@ defmodule Viche.AgentServer do
           capabilities: [String.t()],
           description: String.t() | nil,
           registries: [String.t()] | nil,
-          polling_timeout_ms: pos_integer() | nil
+          polling_timeout_ms: pos_integer() | nil,
+          grace_period_ms: pos_integer() | nil
         ]
 
   # Never restart — dynamic agents re-register with a new ID on crash
@@ -85,6 +86,11 @@ defmodule Viche.AgentServer do
     GenServer.call(server, :inspect_inbox)
   end
 
+  @spec heartbeat(GenServer.server()) :: :ok
+  def heartbeat(server) do
+    GenServer.call(server, :heartbeat)
+  end
+
   # ---------------------------------------------------------------------------
   # GenServer callbacks
   # ---------------------------------------------------------------------------
@@ -97,6 +103,7 @@ defmodule Viche.AgentServer do
     description = Keyword.get(opts, :description)
     registries = Keyword.get(opts, :registries, ["global"])
     polling_timeout_ms = Keyword.get(opts, :polling_timeout_ms, 60_000)
+    grace_period_ms = Keyword.get(opts, :grace_period_ms)
 
     registered_at = DateTime.utc_now()
 
@@ -109,7 +116,8 @@ defmodule Viche.AgentServer do
       inbox: [],
       registered_at: registered_at,
       last_activity: registered_at,
-      polling_timeout_ms: polling_timeout_ms
+      polling_timeout_ms: polling_timeout_ms,
+      grace_period_ms: grace_period_ms
     }
 
     Process.send_after(self(), :check_polling_timeout, polling_timeout_ms)
@@ -147,6 +155,14 @@ defmodule Viche.AgentServer do
   end
 
   @impl GenServer
+  def handle_call(:heartbeat, _from, {%Agent{} = agent, meta}) do
+    updated = %Agent{agent | last_activity: DateTime.utc_now()}
+    reschedule_polling_timeout(updated)
+    Logger.debug("Agent #{agent.id} heartbeat received, last_activity updated")
+    {:reply, :ok, {updated, meta}}
+  end
+
+  @impl GenServer
   def handle_info(:websocket_connected, {%Agent{} = agent, %{grace_timer_ref: ref} = meta}) do
     cancel_grace_timer(ref)
     updated_agent = %Agent{agent | connection_type: :websocket}
@@ -162,7 +178,7 @@ defmodule Viche.AgentServer do
 
   @impl GenServer
   def handle_info(:websocket_disconnected, {%Agent{} = agent, meta}) do
-    grace_ms = grace_period_ms()
+    grace_ms = grace_period_ms(agent)
     ref = Process.send_after(self(), :deregister_grace_expired, grace_ms)
     Logger.debug("Agent #{agent.id} WebSocket disconnected, grace period started (#{grace_ms}ms)")
     {:noreply, {agent, %{meta | grace_timer_ref: ref}}}
@@ -231,6 +247,7 @@ defmodule Viche.AgentServer do
     :ok
   end
 
-  @spec grace_period_ms() :: pos_integer()
-  defp grace_period_ms, do: Application.get_env(:viche, :grace_period_ms, 5_000)
+  @spec grace_period_ms(Agent.t()) :: pos_integer()
+  defp grace_period_ms(%Agent{grace_period_ms: ms}) when is_integer(ms) and ms > 0, do: ms
+  defp grace_period_ms(_agent), do: Application.get_env(:viche, :grace_period_ms, 60_000)
 end

--- a/lib/viche/agents.ex
+++ b/lib/viche/agents.ex
@@ -305,6 +305,26 @@ defmodule Viche.Agents do
     end
   end
 
+  @doc """
+  Sends a heartbeat for the given agent, resetting its `last_activity` timestamp
+  and polling timeout timer without consuming messages.
+
+  ## Returns
+    - `:ok` — heartbeat acknowledged
+    - `{:error, :agent_not_found}`
+  """
+  @spec heartbeat(String.t()) :: :ok | {:error, :agent_not_found}
+  def heartbeat(agent_id) do
+    case lookup_agent(agent_id) do
+      :not_found ->
+        {:error, :agent_not_found}
+
+      :found ->
+        via = {:via, Registry, {Viche.AgentRegistry, agent_id}}
+        AgentServer.heartbeat(via)
+    end
+  end
+
   @token_regex ~r/^[a-zA-Z0-9._-]+$/
 
   @doc """
@@ -432,6 +452,7 @@ defmodule Viche.Agents do
     name = Map.get(attrs, :name)
     description = Map.get(attrs, :description)
     polling_timeout_ms = Map.get(attrs, :polling_timeout_ms)
+    grace_period_ms = Map.get(attrs, :grace_period_ms)
     agent_id = generate_unique_id()
 
     child_opts = [
@@ -445,6 +466,11 @@ defmodule Viche.Agents do
     child_opts =
       if polling_timeout_ms,
         do: Keyword.put(child_opts, :polling_timeout_ms, polling_timeout_ms),
+        else: child_opts
+
+    child_opts =
+      if grace_period_ms,
+        do: Keyword.put(child_opts, :grace_period_ms, grace_period_ms),
         else: child_opts
 
     child_spec = {AgentServer, child_opts}

--- a/lib/viche_web/channels/agent_channel.ex
+++ b/lib/viche_web/channels/agent_channel.ex
@@ -154,6 +154,16 @@ defmodule VicheWeb.AgentChannel do
     end
   end
 
+  def handle_in("heartbeat", _params, socket) do
+    case Viche.Agents.heartbeat(socket.assigns.agent_id) do
+      :ok ->
+        {:reply, {:ok, %{status: "ok"}}, socket}
+
+      {:error, reason} ->
+        {:reply, {:error, %{error: to_string(reason), message: to_string(reason)}}, socket}
+    end
+  end
+
   def handle_in("drain_inbox", _params, socket) do
     case Viche.Agents.drain_inbox(socket.assigns.agent_id) do
       {:ok, messages} ->

--- a/lib/viche_web/controllers/heartbeat_controller.ex
+++ b/lib/viche_web/controllers/heartbeat_controller.ex
@@ -1,0 +1,29 @@
+defmodule VicheWeb.HeartbeatController do
+  @moduledoc """
+  Handles agent heartbeat requests.
+
+  A heartbeat resets the agent's `last_activity` timestamp and polling timeout
+  timer without consuming messages. Useful for keeping idle long-poll agents alive.
+
+  Thin HTTP adapter — all business logic lives in `Viche.Agents`.
+  """
+
+  use VicheWeb, :controller
+
+  alias Viche.Agents
+
+  @spec heartbeat(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def heartbeat(conn, %{"agent_id" => agent_id}) do
+    case Agents.heartbeat(agent_id) do
+      :ok ->
+        conn
+        |> put_status(:ok)
+        |> json(%{status: "ok"})
+
+      {:error, :agent_not_found} ->
+        conn
+        |> put_status(:not_found)
+        |> json(%{error: "agent_not_found"})
+    end
+  end
+end

--- a/lib/viche_web/controllers/registry_controller.ex
+++ b/lib/viche_web/controllers/registry_controller.ex
@@ -10,18 +10,22 @@ defmodule VicheWeb.RegistryController do
   alias Viche.Agents
 
   @min_polling_timeout_ms 5_000
+  @min_grace_period_ms 1_000
 
   @spec register(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def register(conn, params) do
     polling_timeout_ms = Map.get(params, "polling_timeout_ms")
+    grace_period_ms = Map.get(params, "grace_period_ms")
     registries = Map.get(params, "registries")
 
     with :ok <- validate_polling_timeout(polling_timeout_ms),
+         :ok <- validate_grace_period(grace_period_ms),
          attrs = %{
            capabilities: Map.get(params, "capabilities"),
            name: Map.get(params, "name"),
            description: Map.get(params, "description"),
            polling_timeout_ms: polling_timeout_ms,
+           grace_period_ms: grace_period_ms,
            registries: registries
          },
          {:ok, agent} <- Agents.register_agent(attrs) do
@@ -35,13 +39,19 @@ defmodule VicheWeb.RegistryController do
         registries: agent.registries,
         inbox_url: "/inbox/#{agent.id}",
         registered_at: DateTime.to_iso8601(agent.registered_at),
-        polling_timeout_ms: agent.polling_timeout_ms
+        polling_timeout_ms: agent.polling_timeout_ms,
+        grace_period_ms: agent.grace_period_ms
       })
     else
       {:error, :invalid_polling_timeout} ->
         conn
         |> put_status(:unprocessable_entity)
         |> json(%{error: "invalid_polling_timeout"})
+
+      {:error, :invalid_grace_period} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(%{error: "invalid_grace_period"})
 
       {:error, :capabilities_required} ->
         conn
@@ -113,6 +123,15 @@ defmodule VicheWeb.RegistryController do
     do: :ok
 
   defp validate_polling_timeout(_), do: {:error, :invalid_polling_timeout}
+
+  @spec validate_grace_period(nil | integer() | term()) ::
+          :ok | {:error, :invalid_grace_period}
+  defp validate_grace_period(nil), do: :ok
+
+  defp validate_grace_period(ms) when is_integer(ms) and ms >= @min_grace_period_ms,
+    do: :ok
+
+  defp validate_grace_period(_), do: {:error, :invalid_grace_period}
 
   @spec validate_discover_token(nil | String.t()) ::
           :ok | {:error, :invalid_token}

--- a/lib/viche_web/router.ex
+++ b/lib/viche_web/router.ex
@@ -59,6 +59,12 @@ defmodule VicheWeb.Router do
     get "/:agent_id", InboxController, :read_inbox
   end
 
+  scope "/agents", VicheWeb do
+    pipe_through :api
+
+    post "/:agent_id/heartbeat", HeartbeatController, :heartbeat
+  end
+
   # Enable LiveDashboard and Swoosh mailbox preview in development
   if Application.compile_env(:viche, :dev_routes) do
     # If you want to use the LiveDashboard in production, you should put

--- a/test/viche/agent_server_test.exs
+++ b/test/viche/agent_server_test.exs
@@ -225,17 +225,17 @@ defmodule Viche.AgentServerTest do
     end
 
     test "inbox read resets the polling timer and keeps agent alive" do
-      # Register with 200ms timeout
-      {_id, pid} = start_agent(polling_timeout_ms: 200)
+      # Register with 500ms timeout
+      {_id, pid} = start_agent(polling_timeout_ms: 500)
 
-      # Poll at 150ms (before timeout)
-      Process.sleep(150)
+      # Poll at 350ms (before timeout)
+      Process.sleep(350)
       AgentServer.drain_inbox(pid)
 
-      # Wait 100ms more (total ~250ms but timer was reset at 150ms)
-      Process.sleep(100)
+      # Wait 300ms more (total ~650ms but timer was reset at 350ms)
+      Process.sleep(300)
 
-      # Agent should still be alive (new timeout of 200ms from poll time has not expired)
+      # Agent should still be alive (new timeout of 500ms from poll time has not expired)
       assert Process.alive?(pid)
     end
 
@@ -267,6 +267,65 @@ defmodule Viche.AgentServerTest do
 
       state_after = AgentServer.get_state(pid)
       assert DateTime.compare(state_after.last_activity, initial_activity) == :gt
+    end
+  end
+
+  describe "heartbeat/1" do
+    test "heartbeat updates last_activity to current time" do
+      {_id, pid} = start_agent()
+      state_before = AgentServer.get_state(pid)
+      initial_activity = state_before.last_activity
+
+      Process.sleep(10)
+      assert :ok = AgentServer.heartbeat(pid)
+
+      state_after = AgentServer.get_state(pid)
+      assert DateTime.compare(state_after.last_activity, initial_activity) == :gt
+    end
+
+    test "heartbeat keeps long-poll agent alive past original timeout" do
+      {_id, pid} = start_agent(polling_timeout_ms: 500)
+
+      # Wait 350ms (close to timeout), then heartbeat
+      Process.sleep(350)
+      AgentServer.heartbeat(pid)
+
+      # Wait another 300ms — total 650ms but timer was reset at 350ms
+      Process.sleep(300)
+
+      assert Process.alive?(pid)
+    end
+
+    test "heartbeat does not consume inbox messages" do
+      {_id, pid} = start_agent()
+
+      message = %Viche.Message{
+        id: "msg-test",
+        type: "task",
+        from: "sender",
+        body: "hello",
+        sent_at: DateTime.utc_now()
+      }
+
+      AgentServer.receive_message(pid, message)
+      AgentServer.heartbeat(pid)
+
+      inbox = AgentServer.inspect_inbox(pid)
+      assert length(inbox) == 1
+    end
+  end
+
+  describe "grace_period_ms per-agent override" do
+    test "agent stores grace_period_ms from opts" do
+      {_id, pid} = start_agent(grace_period_ms: 300_000)
+      state = AgentServer.get_state(pid)
+      assert state.grace_period_ms == 300_000
+    end
+
+    test "grace_period_ms defaults to nil when not provided" do
+      {_id, pid} = start_agent()
+      state = AgentServer.get_state(pid)
+      assert state.grace_period_ms == nil
     end
   end
 end

--- a/test/viche_web/controllers/heartbeat_controller_test.exs
+++ b/test/viche_web/controllers/heartbeat_controller_test.exs
@@ -1,0 +1,59 @@
+defmodule VicheWeb.HeartbeatControllerTest do
+  use VicheWeb.ConnCase, async: false
+
+  alias Viche.AgentServer
+
+  defp register_agent(conn, opts \\ []) do
+    params = Map.merge(%{"capabilities" => ["coding"]}, Map.new(opts))
+    conn = post(conn, ~p"/registry/register", params)
+    %{"id" => id} = json_response(conn, 201)
+    id
+  end
+
+  describe "POST /agents/:agent_id/heartbeat" do
+    test "returns 200 OK for a registered agent", %{conn: conn} do
+      agent_id = register_agent(conn)
+
+      conn = post(build_conn(), ~p"/agents/#{agent_id}/heartbeat")
+
+      assert %{"status" => "ok"} = json_response(conn, 200)
+    end
+
+    test "returns 404 for non-existent agent", %{conn: conn} do
+      conn = post(conn, ~p"/agents/nonexistent-id/heartbeat")
+
+      assert %{"error" => "agent_not_found"} = json_response(conn, 404)
+    end
+
+    test "heartbeat updates last_activity timestamp", %{conn: conn} do
+      agent_id = register_agent(conn)
+
+      state_before = AgentServer.get_state({:via, Registry, {Viche.AgentRegistry, agent_id}})
+      initial_activity = state_before.last_activity
+
+      Process.sleep(10)
+
+      post(build_conn(), ~p"/agents/#{agent_id}/heartbeat")
+
+      state_after =
+        AgentServer.get_state({:via, Registry, {Viche.AgentRegistry, agent_id}})
+
+      assert DateTime.compare(state_after.last_activity, initial_activity) == :gt
+    end
+
+    test "heartbeat keeps long-poll agent alive past original timeout", %{conn: conn} do
+      agent_id = register_agent(conn, [{"polling_timeout_ms", 5_000}])
+
+      [{pid, _}] = Registry.lookup(Viche.AgentRegistry, agent_id)
+
+      post(build_conn(), ~p"/agents/#{agent_id}/heartbeat")
+
+      via = {:via, Registry, {Viche.AgentRegistry, agent_id}}
+      state = Viche.AgentServer.get_state(via)
+
+      # Verify heartbeat updated last_activity
+      assert DateTime.compare(state.last_activity, state.registered_at) != :lt
+      assert Process.alive?(pid)
+    end
+  end
+end


### PR DESCRIPTION
Improve agent connection stability with two changes:

- Increase default WebSocket grace period from 5s to 60s, make it
  configurable per-agent via grace_period_ms registration param
- Add heartbeat endpoint (POST /agents/:id/heartbeat) and WebSocket
  "heartbeat" event to reset polling timeout without consuming messages