### PR TITLE
fix: pass agent_id in openclaw plugin registry channel join

### DIFF
--- a/channel/openclaw-plugin-viche/service.ts
+++ b/channel/openclaw-plugin-viche/service.ts
@@ -312,7 +312,9 @@ export function createVicheService(
               );
 
               for (const token of config.registries ?? []) {
-                const registryChannel = socket!.channel(`registry:${token}`, {});
+                const registryChannel = socket!.channel(`registry:${token}`, {
+                  agent_id: state.agentId,
+                });
                 registryChannel
                   .join()
                   .receive("error", (resp: unknown) => {


### PR DESCRIPTION
## Summary

- The opencode plugin was fixed in b6ec707 to pass `agent_id` when joining registry channels, but the same fix was missed for the openclaw plugin
- Phoenix channels have isolated socket assigns per channel process, so `agent_id` set during `agent:register` join is not available in a separate `registry:{token}` channel join
- Without `agent_id` in params, the server rejects with `agent_id_required`, causing repeated retry spam in logs every ~10 seconds

## Changes

One-line fix in `channel/openclaw-plugin-viche/service.ts`: pass `{ agent_id: state.agentId }` instead of `{}` when joining registry channels — identical to the opencode plugin fix.

## Test plan

- [ ] Verify openclaw plugin successfully joins registry channels after registration
- [ ] Verify no more `agent_id_required` errors in logs
- [ ] Existing `channel-error-recovery.test.ts` and `e2e.test.ts` should still pass