### PR TITLE
feat: Message Correlation & Threading (in_reply_to + conversation_id)

### DIFF
--- a/channel/claude-code-plugin-viche/service.ts
+++ b/channel/claude-code-plugin-viche/service.ts
@@ -232,21 +232,32 @@ function connectAndRegister(server: Server): Promise<void> {
 
     registerChannel.on(
       "new_message",
-      (payload: { id: string; type?: string; from: string; body: string }) => {
+      (payload: {
+        id: string;
+        type?: string;
+        from: string;
+        body: string;
+        in_reply_to?: string;
+        conversation_id?: string;
+      }) => {
         const messageType = payload.type ?? "task";
         const displayType =
           messageType.charAt(0).toUpperCase() + messageType.slice(1);
+
+        const meta: Record<string, unknown> = {
+          message_id: payload.id,
+          from: payload.from,
+          type: messageType,
+        };
+        if (payload.in_reply_to) meta.in_reply_to = payload.in_reply_to;
+        if (payload.conversation_id) meta.conversation_id = payload.conversation_id;
 
         server
           .notification({
             method: "notifications/claude/channel",
             params: {
               content: `[${displayType} from ${payload.from}] ${payload.body}`,
-              meta: {
-                message_id: payload.id,
-                from: payload.from,
-                type: messageType,
-              },
+              meta,
             },
           })
           .catch((err: unknown) => {

--- a/channel/claude-code-plugin-viche/tools.ts
+++ b/channel/claude-code-plugin-viche/tools.ts
@@ -57,6 +57,14 @@ const TOOL_DEFINITIONS = [
           description: "Message type: 'task', 'result', or 'ping'",
           default: "task",
         },
+        in_reply_to: {
+          type: "string",
+          description: "Optional message ID this message is replying to (for threading)",
+        },
+        conversation_id: {
+          type: "string",
+          description: "Optional conversation ID to group related messages into a thread",
+        },
       },
       required: ["to", "body"],
     },
@@ -75,6 +83,14 @@ const TOOL_DEFINITIONS = [
         body: {
           type: "string",
           description: "Your result or response",
+        },
+        in_reply_to: {
+          type: "string",
+          description: "Optional message ID this reply is in response to (for threading)",
+        },
+        conversation_id: {
+          type: "string",
+          description: "Optional conversation ID to group related messages into a thread",
         },
       },
       required: ["to", "body"],
@@ -246,6 +262,8 @@ export function registerToolHandlers(
         to: string;
         body: string;
         type?: string;
+        in_reply_to?: string;
+        conversation_id?: string;
       };
       const msgType = args.type ?? "task";
       try {
@@ -254,11 +272,15 @@ export function registerToolHandlers(
           return notConnectedResponse();
         }
 
-        await channelPush(channel, "send_message", {
+        const payload: Record<string, unknown> = {
           to: args.to,
           body: args.body,
           type: msgType,
-        });
+        };
+        if (args.in_reply_to) payload.in_reply_to = args.in_reply_to;
+        if (args.conversation_id) payload.conversation_id = args.conversation_id;
+
+        await channelPush(channel, "send_message", payload);
         return {
           content: [
             {
@@ -276,18 +298,27 @@ export function registerToolHandlers(
     }
 
     if (toolName === "viche_reply") {
-      const args = request.params.arguments as { to: string; body: string };
+      const args = request.params.arguments as {
+        to: string;
+        body: string;
+        in_reply_to?: string;
+        conversation_id?: string;
+      };
       try {
         const channel = getChannel();
         if (!channel) {
           return notConnectedResponse();
         }
 
-        await channelPush(channel, "send_message", {
+        const payload: Record<string, unknown> = {
           to: args.to,
           body: args.body,
           type: "result",
-        });
+        };
+        if (args.in_reply_to) payload.in_reply_to = args.in_reply_to;
+        if (args.conversation_id) payload.conversation_id = args.conversation_id;
+
+        await channelPush(channel, "send_message", payload);
         return {
           content: [{ type: "text", text: `Reply sent to ${args.to}.` }],
         };

--- a/channel/openclaw-plugin-viche/service.ts
+++ b/channel/openclaw-plugin-viche/service.ts
@@ -64,7 +64,7 @@ const CORRELATION_TTL_MS = 60 * 60 * 1_000; // 1 hour
  * Resolve the target sessionKey for an inbound message.
  *
  * Routing priority:
- *   1. "result" messages with a `replyTo` field: look up the correlation map
+ *   1. "result" messages with a `in_reply_to` field: look up the correlation map
  *      to find which session originally sent that message.
  *   2. "most-recent" policy (default when `defaultInboundSession` is unset or "most-recent"):
  *      use the last session that called viche_send or viche_reply (if any).
@@ -76,11 +76,11 @@ function resolveSessionKey(
   state: VicheState,
 ): string {
   // 1. Correlation-based routing for "result" replies.
-  if (payload.type === "result" && payload.replyTo) {
-    const entry = state.correlations.get(payload.replyTo);
+  if (payload.type === "result" && payload.in_reply_to) {
+    const entry = state.correlations.get(payload.in_reply_to);
     if (entry) {
       // Consume the correlation entry — one-time use.
-      state.correlations.delete(payload.replyTo);
+      state.correlations.delete(payload.in_reply_to);
       return entry.sessionKey;
     }
   }

--- a/channel/openclaw-plugin-viche/tools.ts
+++ b/channel/openclaw-plugin-viche/tools.ts
@@ -262,10 +262,20 @@ export function registerVicheTools(
               default: "task",
             }),
           ),
+          in_reply_to: Type.Optional(
+            Type.String({
+              description: "Optional message ID this message is replying to (for threading)",
+            }),
+          ),
+          conversation_id: Type.Optional(
+            Type.String({
+              description: "Optional conversation ID to group related messages into a thread",
+            }),
+          ),
         }),
         async execute(
           _toolCallId: string,
-          params: { to: string; body: string; type?: string },
+          params: { to: string; body: string; type?: string; in_reply_to?: string; conversation_id?: string },
           _signal?: AbortSignal,
         ): Promise<AgentToolResult> {
           const guard = requireConnected(state);
@@ -276,13 +286,17 @@ export function registerVicheTools(
 
           const msgType = params.type ?? "task";
 
+          const sendPayload: Record<string, unknown> = {
+            to: params.to,
+            body: params.body,
+            type: msgType,
+          };
+          if (params.in_reply_to) sendPayload.in_reply_to = params.in_reply_to;
+          if (params.conversation_id) sendPayload.conversation_id = params.conversation_id;
+
           let data: SendMessageResponse | null = null;
           try {
-            data = (await pushChannel(state.channel!, "send_message", {
-              to: params.to,
-              body: params.body,
-              type: msgType,
-            })) as SendMessageResponse;
+            data = (await pushChannel(state.channel!, "send_message", sendPayload)) as SendMessageResponse;
           } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
             return textResult(`Failed to send message: ${msg}`);
@@ -328,10 +342,20 @@ export function registerVicheTools(
           body: Type.String({
             description: "Your result, answer, or response to send back",
           }),
+          in_reply_to: Type.Optional(
+            Type.String({
+              description: "Optional message ID this reply is in response to (for threading)",
+            }),
+          ),
+          conversation_id: Type.Optional(
+            Type.String({
+              description: "Optional conversation ID to group related messages into a thread",
+            }),
+          ),
         }),
         async execute(
           _toolCallId: string,
-          params: { to: string; body: string },
+          params: { to: string; body: string; in_reply_to?: string; conversation_id?: string },
           _signal?: AbortSignal,
         ): Promise<AgentToolResult> {
           const guard = requireConnected(state);
@@ -340,12 +364,16 @@ export function registerVicheTools(
           // Track session activity for "most-recent" inbound routing.
           state.mostRecentSessionKey = sessionKey;
 
+          const replyPayload: Record<string, unknown> = {
+            to: params.to,
+            body: params.body,
+            type: "result",
+          };
+          if (params.in_reply_to) replyPayload.in_reply_to = params.in_reply_to;
+          if (params.conversation_id) replyPayload.conversation_id = params.conversation_id;
+
           try {
-            const response = await pushChannel(state.channel!, "send_message", {
-              to: params.to,
-              body: params.body,
-              type: "result",
-            });
+            const response = await pushChannel(state.channel!, "send_message", replyPayload);
 
             if (!getMessageId(response)) {
               return textResult(

--- a/channel/openclaw-plugin-viche/types.ts
+++ b/channel/openclaw-plugin-viche/types.ts
@@ -396,7 +396,9 @@ export interface InboundMessagePayload {
    * Present when the Viche server populates reply correlation.
    * Used to route "result" messages back to the originating session.
    */
-  replyTo?: string;
+  in_reply_to?: string;
+  /** Optional conversation ID grouping related messages into a thread. */
+  conversation_id?: string;
 }
 
 /** Response body from POST /messages/:agentId (Viche send endpoint). */

--- a/channel/opencode-plugin-viche/__tests__/service.test.ts
+++ b/channel/opencode-plugin-viche/__tests__/service.test.ts
@@ -327,7 +327,31 @@ describe("createVicheService", () => {
     expect(args[0].path.id).toBe("sess-4");
     expect(args[0].body.noReply).toBe(false);
     expect(args[0].body.parts[0]?.text).toContain("[Viche Task from other-agent]");
+    expect(args[0].body.parts[0]?.text).not.toContain("reply_to:");
+    expect(args[0].body.parts[0]?.text).not.toContain("thread:");
     expect(args[0].body.parts[0]?.text).toContain("Please review this PR");
+  });
+
+  it("injects inbound task message with threading context when provided", async () => {
+    const service = createVicheService(config, state, client, "/project");
+    await service.ensureSessionReady("sess-4-threaded");
+
+    const payload = {
+      id: "msg-001-threaded",
+      from: "other-agent",
+      body: "Please review this PR",
+      type: "task",
+      in_reply_to: "msg-parent-123",
+      conversation_id: "conv-abc",
+    };
+    await _onHandlers["new_message"]!(payload);
+
+    expect(client.session.promptAsync).toHaveBeenCalledTimes(1);
+    const [callArgs] = (client.session.promptAsync as ReturnType<typeof mock>).mock.calls;
+    const args = callArgs as [{ body: { parts: Array<{ text: string }> } }];
+    expect(args[0].body.parts[0]?.text).toContain(
+      "[Viche Task from other-agent (reply_to:msg-parent-123 thread:conv-abc)]"
+    );
   });
 
   it("injects inbound result message via client.session.promptAsync", async () => {

--- a/channel/opencode-plugin-viche/__tests__/tools.test.ts
+++ b/channel/opencode-plugin-viche/__tests__/tools.test.ts
@@ -96,6 +96,37 @@ describe("createVicheTools (WebSocket transport)", () => {
     expect(result).toContain("Message sent to deadbeef-0000-4000-a000-000000000000");
   });
 
+  it("viche_send passes optional threading fields when provided", async () => {
+    const push = makeChannelPush("ok", { message_id: "msg-thread-1" });
+    const ensureSessionReady = mock((_sessionID: string) =>
+      Promise.resolve(makeSessionState(push))
+    );
+
+    const tools = createVicheTools(makeConfig(), makeState(), ensureSessionReady);
+    const result = await tools.viche_send.execute(
+      {
+        to: "deadbeef-0000-4000-a000-000000000000",
+        body: "Threaded follow-up",
+        type: "task",
+        in_reply_to: "msg-parent-123",
+        conversation_id: "conv-xyz",
+      },
+      TEST_CONTEXT
+    );
+
+    expect(push).toHaveBeenCalledTimes(1);
+    const [event, payload] = push.mock.calls[0] as [string, Record<string, unknown>];
+    expect(event).toBe("send_message");
+    expect(payload).toEqual({
+      to: "deadbeef-0000-4000-a000-000000000000",
+      body: "Threaded follow-up",
+      type: "task",
+      in_reply_to: "msg-parent-123",
+      conversation_id: "conv-xyz",
+    });
+    expect(result).toContain("Message sent to deadbeef-0000-4000-a000-000000000000");
+  });
+
   it("viche_reply uses send_message with type result and no from", async () => {
     const push = makeChannelPush("ok", { message_id: "msg-2" });
     const ensureSessionReady = mock((_sessionID: string) =>
@@ -117,6 +148,34 @@ describe("createVicheTools (WebSocket transport)", () => {
       type: "result",
     });
     expect(payload.from).toBeUndefined();
+    expect(result).toContain("Reply sent to cafebabe-0000-4000-a000-000000000000");
+  });
+
+  it("viche_reply passes optional in_reply_to when provided", async () => {
+    const push = makeChannelPush("ok", { message_id: "msg-thread-2" });
+    const ensureSessionReady = mock((_sessionID: string) =>
+      Promise.resolve(makeSessionState(push))
+    );
+
+    const tools = createVicheTools(makeConfig(), makeState(), ensureSessionReady);
+    const result = await tools.viche_reply.execute(
+      {
+        to: "cafebabe-0000-4000-a000-000000000000",
+        body: "Done",
+        in_reply_to: "msg-parent-456",
+      },
+      TEST_CONTEXT
+    );
+
+    expect(push).toHaveBeenCalledTimes(1);
+    const [event, payload] = push.mock.calls[0] as [string, Record<string, unknown>];
+    expect(event).toBe("send_message");
+    expect(payload).toEqual({
+      to: "cafebabe-0000-4000-a000-000000000000",
+      body: "Done",
+      type: "result",
+      in_reply_to: "msg-parent-456",
+    });
     expect(result).toContain("Reply sent to cafebabe-0000-4000-a000-000000000000");
   });
 

--- a/channel/opencode-plugin-viche/service.ts
+++ b/channel/opencode-plugin-viche/service.ts
@@ -273,6 +273,10 @@ export function createVicheService(
     payload: InboundMessagePayload
   ): Promise<void> {
     const label = payload.type === "result" ? "Result" : "Task";
+    const threadParts: string[] = [];
+    if (payload.in_reply_to) threadParts.push(`reply_to:${payload.in_reply_to}`);
+    if (payload.conversation_id) threadParts.push(`thread:${payload.conversation_id}`);
+    const threadContext = threadParts.length > 0 ? ` (${threadParts.join(" ")})` : "";
     // Sanitize body: replace newlines and carriage returns with a space to
     // prevent prompt-injection attacks that break out of the enclosing bracket.
     const sanitizedBody = payload.body.replace(/[\r\n]/g, " ");
@@ -283,7 +287,7 @@ export function createVicheService(
         parts: [
           {
             type: "text",
-            text: `[Viche ${label} from ${payload.from}] ${sanitizedBody}`,
+            text: `[Viche ${label} from ${payload.from}${threadContext}] ${sanitizedBody}`,
           },
         ],
       },

--- a/channel/opencode-plugin-viche/tools.ts
+++ b/channel/opencode-plugin-viche/tools.ts
@@ -113,6 +113,8 @@ interface PostMessageArgs {
   to: string;
   body: string;
   type: string;
+  in_reply_to?: string;
+  conversation_id?: string;
 }
 
 const MessageAckSchema = z.object({
@@ -130,11 +132,13 @@ const MessageAckSchema = z.object({
 async function postMessage(
   args: PostMessageArgs
 ): Promise<PushResult<{ message_id: string }>> {
-  const { channel, to, body, type } = args;
+  const { channel, to, body, type, in_reply_to, conversation_id } = args;
   const result = await pushWithAck<{ message_id?: string }>(channel, "send_message", {
     to,
     body,
     type,
+    ...(in_reply_to !== undefined ? { in_reply_to } : {}),
+    ...(conversation_id !== undefined ? { conversation_id } : {}),
   });
 
   if (!result.ok) {
@@ -293,9 +297,23 @@ export function createVicheTools(
         .optional()
         .default("task")
         .describe("Message type: 'task' (default), 'result', or 'ping'"),
+      in_reply_to: z
+        .string()
+        .optional()
+        .describe("Optional message ID this message replies to"),
+      conversation_id: z
+        .string()
+        .optional()
+        .describe("Optional conversation thread ID"),
     },
     async execute(
-      args: { to: string; body: string; type?: string },
+      args: {
+        to: string;
+        body: string;
+        type?: string;
+        in_reply_to?: string;
+        conversation_id?: string;
+      },
       context: { sessionID: string }
     ): Promise<string> {
       let sessionState: SessionState;
@@ -314,6 +332,10 @@ export function createVicheTools(
         to,
         body,
         type: msgType,
+        ...(args.in_reply_to !== undefined ? { in_reply_to: args.in_reply_to } : {}),
+        ...(args.conversation_id !== undefined
+          ? { conversation_id: args.conversation_id }
+          : {}),
       });
       if (!result.ok) {
         return `Failed to send message: ${result.error ?? "unknown channel error"}`;
@@ -338,9 +360,13 @@ export function createVicheTools(
           "Agent ID to reply to — copy from the 'from' field of the task message you received (UUID)"
         ),
       body: z.string().describe("Your result, answer, or response to send back"),
+      in_reply_to: z
+        .string()
+        .optional()
+        .describe("Optional message ID this reply is responding to"),
     },
     async execute(
-      args: { to: string; body: string },
+      args: { to: string; body: string; in_reply_to?: string },
       context: { sessionID: string }
     ): Promise<string> {
       let sessionState: SessionState;
@@ -358,6 +384,7 @@ export function createVicheTools(
         to,
         body,
         type: "result",
+        ...(args.in_reply_to !== undefined ? { in_reply_to: args.in_reply_to } : {}),
       });
       if (!result.ok) {
         return `Failed to send reply: ${result.error ?? "unknown channel error"}`;

--- a/channel/opencode-plugin-viche/types.ts
+++ b/channel/opencode-plugin-viche/types.ts
@@ -83,4 +83,6 @@ export interface InboundMessagePayload {
   from: string;
   body: string;
   type: string;
+  in_reply_to?: string;
+  conversation_id?: string;
 }

--- a/lib/viche/agents.ex
+++ b/lib/viche/agents.ex
@@ -471,6 +471,8 @@ defmodule Viche.Agents do
   ## Parameters
     - `%{to: agent_id, from: sender, body: text}` — required keys
     - `:type` — optional, defaults to `"task"`. Must be one of `"task"`, `"result"`, `"ping"`.
+    - `:in_reply_to` — optional message ID this message replies to
+    - `:conversation_id` — optional thread identifier
 
   ## Returns
     - `{:ok, message_id}` — fire-and-forget; message_id starts with `"msg-"`
@@ -482,15 +484,21 @@ defmodule Viche.Agents do
   def send_message(%{to: agent_id, from: from, body: body} = attrs)
       when is_binary(from) and from != "" and is_binary(body) and body != "" do
     type = Map.get(attrs, :type, "task")
+    in_reply_to = Map.get(attrs, :in_reply_to)
+    conversation_id = Map.get(attrs, :conversation_id)
 
     with true <- Message.valid_type?(type),
+         :ok <- validate_optional_string(in_reply_to, :invalid_message),
+         :ok <- validate_optional_string(conversation_id, :invalid_message),
          :found <- lookup_agent(agent_id) do
       message = %Message{
         id: generate_message_id(),
         type: type,
         from: from,
         body: body,
-        sent_at: DateTime.utc_now()
+        sent_at: DateTime.utc_now(),
+        in_reply_to: in_reply_to,
+        conversation_id: conversation_id
       }
 
       via = {:via, Registry, {Viche.AgentRegistry, agent_id}}
@@ -503,7 +511,9 @@ defmodule Viche.Agents do
         type: message.type,
         from: message.from,
         body: message.body,
-        sent_at: DateTime.to_iso8601(message.sent_at)
+        sent_at: DateTime.to_iso8601(message.sent_at),
+        in_reply_to: message.in_reply_to,
+        conversation_id: message.conversation_id
       })
 
       {:ok, message.id}

--- a/lib/viche/message.ex
+++ b/lib/viche/message.ex
@@ -11,10 +11,12 @@ defmodule Viche.Message do
           type: String.t(),
           from: String.t(),
           body: String.t(),
-          sent_at: DateTime.t()
+          sent_at: DateTime.t(),
+          in_reply_to: String.t() | nil,
+          conversation_id: String.t() | nil
         }
 
-  defstruct [:id, :type, :from, :body, :sent_at]
+  defstruct [:id, :type, :from, :body, :sent_at, :in_reply_to, :conversation_id]
 
   @valid_types ~w(task result ping)
 

--- a/lib/viche_web/channels/agent_channel.ex
+++ b/lib/viche_web/channels/agent_channel.ex
@@ -113,8 +113,17 @@ defmodule VicheWeb.AgentChannel do
   def handle_in("send_message", %{"to" => to, "body" => body} = params, socket) do
     from = socket.assigns.agent_id
     type = Map.get(params, "type", "task")
+    in_reply_to = Map.get(params, "in_reply_to")
+    conversation_id = Map.get(params, "conversation_id")
 
-    case Viche.Agents.send_message(%{to: to, from: from, body: body, type: type}) do
+    case Viche.Agents.send_message(%{
+           to: to,
+           from: from,
+           body: body,
+           type: type,
+           in_reply_to: in_reply_to,
+           conversation_id: conversation_id
+         }) do
       {:ok, message_id} ->
         {:reply, {:ok, %{message_id: message_id}}, socket}
 
@@ -265,7 +274,9 @@ defmodule VicheWeb.AgentChannel do
         type: msg.type,
         from: msg.from,
         body: msg.body,
-        sent_at: DateTime.to_iso8601(msg.sent_at)
+        sent_at: DateTime.to_iso8601(msg.sent_at),
+        in_reply_to: msg.in_reply_to,
+        conversation_id: msg.conversation_id
       }
     end)
   end

--- a/lib/viche_web/controllers/inbox_controller.ex
+++ b/lib/viche_web/controllers/inbox_controller.ex
@@ -58,7 +58,9 @@ defmodule VicheWeb.InboxController do
       type: msg.type,
       from: msg.from,
       body: msg.body,
-      sent_at: DateTime.to_iso8601(msg.sent_at)
+      sent_at: DateTime.to_iso8601(msg.sent_at),
+      in_reply_to: msg.in_reply_to,
+      conversation_id: msg.conversation_id
     }
   end
 end

--- a/lib/viche_web/controllers/message_controller.ex
+++ b/lib/viche_web/controllers/message_controller.ex
@@ -30,7 +30,14 @@ defmodule VicheWeb.MessageController do
     if is_nil(from) do
       invalid_message_response(conn)
     else
-      attrs = %{to: agent_id, from: from, body: body, type: type}
+      attrs = %{
+        to: agent_id,
+        from: from,
+        body: body,
+        type: type,
+        in_reply_to: Map.get(conn.params, "in_reply_to"),
+        conversation_id: Map.get(conn.params, "conversation_id")
+      }
 
       case Agents.send_message(attrs) do
         {:ok, message_id} ->

--- a/test/viche/agents_test.exs
+++ b/test/viche/agents_test.exs
@@ -362,6 +362,24 @@ defmodule Viche.AgentsTest do
       assert msg.from == "aris"
       assert msg.body == "ping!"
       assert msg.type == "ping"
+      assert msg.in_reply_to == nil
+      assert msg.conversation_id == nil
+    end
+
+    test "accepts optional in_reply_to and conversation_id", %{agent_id: agent_id} do
+      assert {:ok, _message_id} =
+               Agents.send_message(%{
+                 to: agent_id,
+                 from: "aris",
+                 body: "reply payload",
+                 type: "result",
+                 in_reply_to: "msg-123",
+                 conversation_id: "conv-xyz"
+               })
+
+      assert {:ok, [msg]} = Agents.inspect_inbox(agent_id)
+      assert msg.in_reply_to == "msg-123"
+      assert msg.conversation_id == "conv-xyz"
     end
   end
 

--- a/test/viche_web/channels/agent_channel_test.exs
+++ b/test/viche_web/channels/agent_channel_test.exs
@@ -221,6 +221,26 @@ defmodule VicheWeb.AgentChannelTest do
       assert_reply ref, :error, %{error: "agent_not_found", message: _}
     end
 
+    test "send_message accepts in_reply_to and conversation_id", %{
+      socket: socket,
+      receiver_id: receiver_id
+    } do
+      ref =
+        push(socket, "send_message", %{
+          "to" => receiver_id,
+          "body" => "threaded reply",
+          "type" => "result",
+          "in_reply_to" => "msg-root",
+          "conversation_id" => "conv-77"
+        })
+
+      assert_reply ref, :ok, %{message_id: _}
+
+      assert {:ok, [msg]} = Agents.inspect_inbox(receiver_id)
+      assert msg.in_reply_to == "msg-root"
+      assert msg.conversation_id == "conv-77"
+    end
+
     test "send_message missing 'to' field returns validation error", %{socket: socket} do
       ref = push(socket, "send_message", %{"body" => "hello", "type" => "result"})
 
@@ -503,7 +523,14 @@ defmodule VicheWeb.AgentChannelTest do
     end
 
     test "returns inbox messages without consuming them", %{socket: socket, agent_id: agent_id} do
-      Agents.send_message(%{to: agent_id, from: "sender", body: "peek", type: "ping"})
+      Agents.send_message(%{
+        to: agent_id,
+        from: "sender",
+        body: "peek",
+        type: "ping",
+        in_reply_to: "msg-prev",
+        conversation_id: "conv-peek"
+      })
 
       ref = push(socket, "inspect_inbox", %{})
       assert_reply ref, :ok, %{messages: messages}
@@ -512,6 +539,8 @@ defmodule VicheWeb.AgentChannelTest do
       [msg] = messages
       assert msg.body == "peek"
       assert msg.from == "sender"
+      assert msg.in_reply_to == "msg-prev"
+      assert msg.conversation_id == "conv-peek"
 
       # Second inspect still returns messages (not consumed)
       ref2 = push(socket, "inspect_inbox", %{})
@@ -531,7 +560,14 @@ defmodule VicheWeb.AgentChannelTest do
     end
 
     test "returns inbox messages and consumes them", %{socket: socket, agent_id: agent_id} do
-      Agents.send_message(%{to: agent_id, from: "sender", body: "drain me", type: "task"})
+      Agents.send_message(%{
+        to: agent_id,
+        from: "sender",
+        body: "drain me",
+        type: "task",
+        in_reply_to: "msg-before",
+        conversation_id: "conv-drain"
+      })
 
       ref = push(socket, "drain_inbox", %{})
       assert_reply ref, :ok, %{messages: messages}
@@ -539,6 +575,8 @@ defmodule VicheWeb.AgentChannelTest do
       assert length(messages) == 1
       [msg] = messages
       assert msg.body == "drain me"
+      assert msg.in_reply_to == "msg-before"
+      assert msg.conversation_id == "conv-drain"
 
       # Second drain returns empty (consumed)
       ref2 = push(socket, "drain_inbox", %{})
@@ -563,6 +601,8 @@ defmodule VicheWeb.AgentChannelTest do
       assert payload.type == "task"
       assert is_binary(payload.id)
       assert is_binary(payload.sent_at)
+      assert payload.in_reply_to == nil
+      assert payload.conversation_id == nil
     end
 
     test "register-on-join client receives new_message push for newly created agent" do

--- a/test/viche_web/controllers/inbox_controller_test.exs
+++ b/test/viche_web/controllers/inbox_controller_test.exs
@@ -20,6 +20,8 @@ defmodule VicheWeb.InboxControllerTest do
   defp send_message(agent_id, opts) do
     type = Keyword.get(opts, :type, "task")
     body = Keyword.get(opts, :body, "hello")
+    in_reply_to = Keyword.get(opts, :in_reply_to)
+    conversation_id = Keyword.get(opts, :conversation_id)
 
     # Use the caller-supplied `from` agent_id when given; fall back to registering
     # a fresh throwaway agent so there is always a valid `current_agent_id`.
@@ -36,7 +38,12 @@ defmodule VicheWeb.InboxControllerTest do
 
     build_conn()
     |> Plug.Conn.assign(:current_agent_id, sender_id)
-    |> post(~p"/messages/#{agent_id}", %{"type" => type, "body" => body})
+    |> post(~p"/messages/#{agent_id}", %{
+      "type" => type,
+      "body" => body,
+      "in_reply_to" => in_reply_to,
+      "conversation_id" => conversation_id
+    })
   end
 
   describe "GET /inbox/:agent_id" do
@@ -77,13 +84,34 @@ defmodule VicheWeb.InboxControllerTest do
       assert Map.has_key?(msg, "from")
       assert Map.has_key?(msg, "body")
       assert Map.has_key?(msg, "sent_at")
+      assert Map.has_key?(msg, "in_reply_to")
+      assert Map.has_key?(msg, "conversation_id")
 
       assert String.starts_with?(msg["id"], "msg-")
       assert msg["type"] == "task"
       assert msg["from"] == "sender-abc"
       assert msg["body"] == "do the thing"
+      assert msg["in_reply_to"] == nil
+      assert msg["conversation_id"] == nil
       # Verify ISO 8601 format
       assert {:ok, _, _} = DateTime.from_iso8601(msg["sent_at"])
+    end
+
+    test "messages include in_reply_to and conversation_id when provided", %{conn: conn} do
+      agent_id = register_agent(conn)
+
+      send_message(agent_id,
+        type: "result",
+        body: "threaded",
+        in_reply_to: "msg-parent",
+        conversation_id: "conv-thread"
+      )
+
+      conn = get(build_conn(), ~p"/inbox/#{agent_id}")
+      %{"messages" => [msg]} = json_response(conn, 200)
+
+      assert msg["in_reply_to"] == "msg-parent"
+      assert msg["conversation_id"] == "conv-thread"
     end
 
     test "second read after consume returns empty list (Erlang receive semantics)", %{conn: conn} do

--- a/test/viche_web/controllers/message_controller_test.exs
+++ b/test/viche_web/controllers/message_controller_test.exs
@@ -83,6 +83,29 @@ defmodule VicheWeb.MessageControllerTest do
       assert %DateTime{} = msg.sent_at
     end
 
+    test "accepts in_reply_to and conversation_id in request body", %{conn: conn} do
+      recipient_id = register_agent(conn)
+      sender_id = register_agent(build_conn(), ["sending"])
+
+      conn =
+        authed_conn(sender_id)
+        |> post(~p"/messages/#{recipient_id}", %{
+          "type" => "result",
+          "body" => "reply body",
+          "in_reply_to" => "msg-parent",
+          "conversation_id" => "conv-123"
+        })
+
+      assert %{"message_id" => _message_id} = json_response(conn, 202)
+
+      via = {:via, Registry, {Viche.AgentRegistry, recipient_id}}
+      state = AgentServer.get_state(via)
+
+      assert [msg] = state.inbox
+      assert msg.in_reply_to == "msg-parent"
+      assert msg.conversation_id == "conv-123"
+    end
+
     test "returns 422 when current_agent_id is nil (unauthenticated sender)", %{conn: conn} do
       recipient_id = register_agent(conn)
 


### PR DESCRIPTION
## Summary

Adds two optional fields to `Viche.Message` — `in_reply_to` and `conversation_id` — enabling message correlation and conversation threading across the entire stack: Elixir server + all 3 plugins.

- **`in_reply_to`** — links a message to the specific message ID it responds to
- **`conversation_id`** — groups a chain of related messages into one thread

Both fields are optional (nil by default), fully backwards-compatible.

## What changed

```
              ┌──────────────────────────────┐
              │       Viche.Message           │
              │  + in_reply_to   (string|nil) │
              │  + conversation_id (string|nil)│
              └──────────────┬───────────────┘
                             │
           ┌─────────────────┼─────────────────┐
           │                 │                  │
    ┌──────┴──────┐  ┌──────┴──────┐  ┌───────┴───────┐
    │  HTTP API   │  │  WebSocket  │  │   Plugins     │
    │  POST +     │  │  send_msg + │  │  claude-code  │
    │  inbox GET  │  │  new_message│  │  openclaw     │
    └─────────────┘  └─────────────┘  │  opencode     │
                                      └───────────────┘
```

### Server (Elixir) — commit c949584
- `lib/viche/message.ex` — Added fields to struct + `@type t`
- `lib/viche/agents.ex` — Accept + serialize in send_message, broadcast
- `lib/viche_web/controllers/message_controller.ex` — Accept from HTTP POST body
- `lib/viche_web/controllers/inbox_controller.ex` — Include in JSON response
- `lib/viche_web/channels/agent_channel.ex` — Accept in WS event, include in format_messages

### Plugins (TypeScript) — commit bf757eb
- `claude-code-plugin-viche` — tools.ts + service.ts: schema + send + inbound
- `openclaw-plugin-viche` — tools.ts + types.ts + service.ts: replyTo → in_reply_to rename + conversation_id
- `opencode-plugin-viche` — tools.ts + types.ts + service.ts + tests

### Tests
- 4 test files updated/added across server + plugins
- 527 tests passing, Dialyzer clean

## What this unlocks

1. **Fan-out / Fan-in** — Send N tasks, collect N results matched by `in_reply_to`
2. **Multi-hop chains** — Zeus → Prometheus → Mnemosyne → back, all threaded
3. **Timeout detection** — Identify tasks with no reply after N seconds
4. **Conversation history** — Group all messages in a workflow by `conversation_id`
5. **Debugging** — Trace any message back through its full chain

## How it was built

This feature was brainstormed, designed, and implemented by **7 AI agents coordinating over the Viche network itself**:

| Agent | Role |
|-------|------|
| Claude, Aether, Zeus×3 | Brainstormed the idea (top convergent theme from 5 agents) |
| Zeus (orchestrator) | Filed issue #78, coordinated all work |
| Mnemosyne ×2 (local + network) | Researched server touchpoints + plugin serialization formats |
| Vulkanus (local + network) | TDD implementation of server side |
| Claude (network) | Implemented all 3 plugins |
| Aether | Volunteered as fan-out test node |

**19 files changed, 373 insertions, 44 deletions. 2 commits. 0 merge conflicts.**

Closes #78