### PR TITLE
fix: registry dropdown missing on production

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -88,8 +88,9 @@ if config_env() == :prod do
   config :viche,
     telemetry_enabled: System.get_env("VICHE_TELEMETRY") not in ~w(false 0)
 
-  # In prod, show public mode by default. Set VICHE_PUBLIC_MODE=false to disable.
-  public_mode = System.get_env("VICHE_PUBLIC_MODE") not in ~w(false 0)
+  # Public mode hides the registry selector and locks the UI to the global registry.
+  # Intended for self-hosted deployments. Set VICHE_PUBLIC_MODE=true to enable.
+  public_mode = System.get_env("VICHE_PUBLIC_MODE") in ~w(true 1)
   config :viche, :public_mode, public_mode
 
   # Email sender: parse EMAIL_FROM env var as "Name <addr>" or plain address.

--- a/lib/viche_web/components/layouts.ex
+++ b/lib/viche_web/components/layouts.ex
@@ -117,7 +117,9 @@ defmodule VicheWeb.Layouts do
             >
               {Map.get(@registry_names, reg, reg)}
             </option>
-            <option value="all" selected={@selected_registry == "all"}>All registries</option>
+            <option :if={@registries != []} value="all" selected={@selected_registry == "all"}>
+              All registries
+            </option>
           </select>
         </div>
       </form>

--- a/lib/viche_web/live/registry_scope.ex
+++ b/lib/viche_web/live/registry_scope.ex
@@ -101,24 +101,17 @@ defmodule VicheWeb.Live.RegistryScope do
   @spec visible_registries(boolean(), String.t() | nil) :: [String.t()]
   def visible_registries(true, _user_id), do: []
 
-  def visible_registries(false, user_id) do
-    {user_registry_ids, membership_ids} =
-      case user_id do
-        id when is_binary(id) ->
-          owned =
-            Viche.Registries.list_user_registries(id)
-            |> Enum.map(& &1.id)
+  def visible_registries(false, nil), do: []
 
-          memberships = Viche.Registries.list_user_memberships(id)
-          {owned, memberships}
+  def visible_registries(false, user_id) when is_binary(user_id) do
+    owned =
+      Viche.Registries.list_user_registries(user_id)
+      |> Enum.map(& &1.id)
 
-        _ ->
-          {[], []}
-      end
-
+    memberships = Viche.Registries.list_user_memberships(user_id)
     agent_registries = Viche.Agents.list_registries()
 
-    (user_registry_ids ++ membership_ids ++ agent_registries)
+    (owned ++ memberships ++ agent_registries)
     |> Enum.uniq()
   end
 

--- a/lib/viche_web/router.ex
+++ b/lib/viche_web/router.ex
@@ -45,9 +45,14 @@ defmodule VicheWeb.Router do
   end
 
   scope "/", VicheWeb do
-    pipe_through [:browser, :require_auth]
+    pipe_through :browser
 
     live "/dashboard", DashboardLive
+  end
+
+  scope "/", VicheWeb do
+    pipe_through [:browser, :require_auth]
+
     live "/agents", AgentsLive
     live "/agents/:id", AgentDetailLive
     live "/sessions", SessionsLive

--- a/test/viche_web/live/agent_detail_live_test.exs
+++ b/test/viche_web/live/agent_detail_live_test.exs
@@ -2,6 +2,21 @@ defmodule VicheWeb.AgentDetailLiveTest do
   use VicheWeb.ConnCase, async: false
   import Phoenix.LiveViewTest
 
+  defp setup_user(_context \\ %{}) do
+    {:ok, user} =
+      Viche.Accounts.create_user(%{
+        email: "agent-detail-test-#{System.unique_integer()}@example.com"
+      })
+
+    {:ok, user: user}
+  end
+
+  defp live_as_user(conn, user, path) do
+    conn
+    |> init_test_session(%{"user_id" => user.id})
+    |> live(path)
+  end
+
   defp register_agent!(attrs) do
     {:ok, agent} = Viche.Agents.register_agent(attrs)
     agent
@@ -69,7 +84,12 @@ defmodule VicheWeb.AgentDetailLiveTest do
   end
 
   describe "URL param — ?registry=" do
-    test "?registry=team-alpha is read and stored as selected_registry", %{conn: conn} do
+    setup :setup_user
+
+    test "?registry=team-alpha is read and stored as selected_registry", %{
+      conn: conn,
+      user: user
+    } do
       # Register a team-alpha agent so the registry exists in the known list
       _alpha =
         register_agent!(%{
@@ -85,13 +105,13 @@ defmodule VicheWeb.AgentDetailLiveTest do
           registries: ["global"]
         })
 
-      {:ok, view, _html} = live(conn, ~p"/agents/#{agent.id}?registry=team-alpha")
+      {:ok, view, _html} = live_as_user(conn, user, ~p"/agents/#{agent.id}?registry=team-alpha")
 
       # The selector reflects the team-alpha registry
       assert has_element?(view, "#registry-selector option[value='team-alpha'][selected]")
     end
 
-    test "unknown ?registry= param defaults to global", %{conn: conn} do
+    test "unknown ?registry= param defaults to global", %{conn: conn, user: user} do
       agent =
         register_agent!(%{
           name: "detail-def-agent",
@@ -99,14 +119,17 @@ defmodule VicheWeb.AgentDetailLiveTest do
           registries: ["global"]
         })
 
-      {:ok, view, _html} = live(conn, ~p"/agents/#{agent.id}?registry=nonexistent-xyz")
+      {:ok, view, _html} =
+        live_as_user(conn, user, ~p"/agents/#{agent.id}?registry=nonexistent-xyz")
 
       assert has_element?(view, "#registry-selector option[value='global'][selected]")
     end
   end
 
   describe "sidebar links carry ?registry= param" do
-    test "sidebar links include the selected registry query param", %{conn: conn} do
+    setup :setup_user
+
+    test "sidebar links include the selected registry query param", %{conn: conn, user: user} do
       _alpha =
         register_agent!(%{
           name: "detail-lnk-alpha",
@@ -121,7 +144,8 @@ defmodule VicheWeb.AgentDetailLiveTest do
           registries: ["global"]
         })
 
-      {:ok, _view, html} = live(conn, ~p"/agents/#{agent.id}?registry=team-alpha")
+      {:ok, _view, html} =
+        live_as_user(conn, user, ~p"/agents/#{agent.id}?registry=team-alpha")
 
       # Sidebar navigation links should carry the registry param forward
       assert html =~ "registry=team-alpha"
@@ -184,7 +208,12 @@ defmodule VicheWeb.AgentDetailLiveTest do
   end
 
   describe "handle_event select_registry" do
-    test "switching registry patches the URL to include ?registry= param", %{conn: conn} do
+    setup :setup_user
+
+    test "switching registry patches the URL to include ?registry= param", %{
+      conn: conn,
+      user: user
+    } do
       _alpha =
         register_agent!(%{
           name: "detail-patch-alpha",
@@ -199,7 +228,7 @@ defmodule VicheWeb.AgentDetailLiveTest do
           registries: ["global"]
         })
 
-      {:ok, view, _html} = live(conn, ~p"/agents/#{agent.id}")
+      {:ok, view, _html} = live_as_user(conn, user, ~p"/agents/#{agent.id}")
 
       render_hook(view, "select_registry", %{"registry" => "team-alpha"})
       _ = :sys.get_state(view.pid)

--- a/test/viche_web/live/agents_live_test.exs
+++ b/test/viche_web/live/agents_live_test.exs
@@ -2,6 +2,19 @@ defmodule VicheWeb.AgentsLiveTest do
   use VicheWeb.ConnCase, async: false
   import Phoenix.LiveViewTest
 
+  defp setup_user(_context \\ %{}) do
+    {:ok, user} =
+      Viche.Accounts.create_user(%{email: "agents-test-#{System.unique_integer()}@example.com"})
+
+    {:ok, user: user}
+  end
+
+  defp live_as_user(conn, user, path) do
+    conn
+    |> init_test_session(%{"user_id" => user.id})
+    |> live(path)
+  end
+
   # Helper to register an agent and ensure cleanup via process monitoring
   defp register_agent!(attrs) do
     {:ok, agent} = Viche.Agents.register_agent(attrs)
@@ -50,20 +63,28 @@ defmodule VicheWeb.AgentsLiveTest do
   end
 
   describe "registry selector UI" do
-    test "selector #registry-selector is present when public_mode is false", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/agents")
+    setup :setup_user
+
+    test "selector #registry-selector is present when public_mode is false", %{
+      conn: conn,
+      user: user
+    } do
+      {:ok, view, _html} = live_as_user(conn, user, ~p"/agents")
       # public_mode defaults to false in test env
       assert has_element?(view, "#registry-selector")
     end
 
-    test "selector is NOT present when public_mode is true", %{conn: conn} do
+    test "selector is NOT present when public_mode is true", %{conn: conn, user: user} do
       Application.put_env(:viche, :public_mode, true)
       on_exit(fn -> Application.delete_env(:viche, :public_mode) end)
-      {:ok, view, _html} = live(conn, ~p"/agents")
+      {:ok, view, _html} = live_as_user(conn, user, ~p"/agents")
       refute has_element?(view, "#registry-selector")
     end
 
-    test "selector shows options for all known registries plus 'All registries'", %{conn: conn} do
+    test "selector shows options for all known registries plus 'All registries'", %{
+      conn: conn,
+      user: user
+    } do
       _global =
         register_agent!(%{name: "opt-global", capabilities: ["coding"], registries: ["global"]})
 
@@ -74,14 +95,14 @@ defmodule VicheWeb.AgentsLiveTest do
           registries: ["team-alpha"]
         })
 
-      {:ok, view, _html} = live(conn, ~p"/agents")
+      {:ok, view, _html} = live_as_user(conn, user, ~p"/agents")
 
       assert has_element?(view, "#registry-selector option[value='global']")
       assert has_element?(view, "#registry-selector option[value='team-alpha']")
       assert has_element?(view, "#registry-selector option[value='all']")
     end
 
-    test "changing selector via phx-change updates the agent list", %{conn: conn} do
+    test "changing selector via phx-change updates the agent list", %{conn: conn, user: user} do
       _global =
         register_agent!(%{
           name: "chg-global",
@@ -96,7 +117,7 @@ defmodule VicheWeb.AgentsLiveTest do
           registries: ["team-alpha"]
         })
 
-      {:ok, view, html} = live(conn, ~p"/agents")
+      {:ok, view, html} = live_as_user(conn, user, ~p"/agents")
       assert html =~ "chg-global"
       refute html =~ "chg-alpha"
 
@@ -111,7 +132,9 @@ defmodule VicheWeb.AgentsLiveTest do
   end
 
   describe "URL param persistence" do
-    test "?registry=team-alpha in URL sets correct filter on mount", %{conn: conn} do
+    setup :setup_user
+
+    test "?registry=team-alpha in URL sets correct filter on mount", %{conn: conn, user: user} do
       _global =
         register_agent!(%{name: "url-global", capabilities: ["coding"], registries: ["global"]})
 
@@ -122,22 +145,22 @@ defmodule VicheWeb.AgentsLiveTest do
           registries: ["team-alpha"]
         })
 
-      {:ok, _view, html} = live(conn, ~p"/agents?registry=team-alpha")
+      {:ok, _view, html} = live_as_user(conn, user, ~p"/agents?registry=team-alpha")
 
       refute html =~ "url-global"
       assert html =~ "url-alpha"
     end
 
-    test "unknown ?registry= param defaults to global", %{conn: conn} do
+    test "unknown ?registry= param defaults to global", %{conn: conn, user: user} do
       _global =
         register_agent!(%{name: "def-global", capabilities: ["coding"], registries: ["global"]})
 
-      {:ok, _view, html} = live(conn, ~p"/agents?registry=nonexistent-registry")
+      {:ok, _view, html} = live_as_user(conn, user, ~p"/agents?registry=nonexistent-registry")
 
       assert html =~ "def-global"
     end
 
-    test "select_registry event updates URL via push_patch", %{conn: conn} do
+    test "select_registry event updates URL via push_patch", %{conn: conn, user: user} do
       _global =
         register_agent!(%{name: "patch-global", capabilities: ["coding"], registries: ["global"]})
 
@@ -148,7 +171,7 @@ defmodule VicheWeb.AgentsLiveTest do
           registries: ["team-alpha"]
         })
 
-      {:ok, view, html} = live(conn, ~p"/agents")
+      {:ok, view, html} = live_as_user(conn, user, ~p"/agents")
       assert html =~ "patch-global"
       refute html =~ "patch-alpha"
 
@@ -225,14 +248,16 @@ defmodule VicheWeb.AgentsLiveTest do
   end
 
   describe "handle_event select_registry" do
-    test "switching to team-alpha shows only team-alpha agents", %{conn: conn} do
+    setup :setup_user
+
+    test "switching to team-alpha shows only team-alpha agents", %{conn: conn, user: user} do
       _global =
         register_agent!(%{name: "g-only", capabilities: ["coding"], registries: ["global"]})
 
       _alpha =
         register_agent!(%{name: "a-only", capabilities: ["testing"], registries: ["team-alpha"]})
 
-      {:ok, view, html} = live(conn, ~p"/agents")
+      {:ok, view, html} = live_as_user(conn, user, ~p"/agents")
       assert html =~ "g-only"
       refute html =~ "a-only"
 
@@ -242,14 +267,14 @@ defmodule VicheWeb.AgentsLiveTest do
       assert html_after =~ "a-only"
     end
 
-    test "switching to :all shows agents from all registries", %{conn: conn} do
+    test "switching to :all shows agents from all registries", %{conn: conn, user: user} do
       _global =
         register_agent!(%{name: "g-all", capabilities: ["coding"], registries: ["global"]})
 
       _alpha =
         register_agent!(%{name: "a-all", capabilities: ["testing"], registries: ["team-alpha"]})
 
-      {:ok, view, _html} = live(conn, ~p"/agents")
+      {:ok, view, _html} = live_as_user(conn, user, ~p"/agents")
 
       # First switch to team-alpha
       render_hook(view, "select_registry", %{"registry" => "team-alpha"})
@@ -261,14 +286,17 @@ defmodule VicheWeb.AgentsLiveTest do
       assert html_all =~ "a-all"
     end
 
-    test "agent_count in footer reflects global total after registry switch", %{conn: conn} do
+    test "agent_count in footer reflects global total after registry switch", %{
+      conn: conn,
+      user: user
+    } do
       _global =
         register_agent!(%{name: "g-cnt", capabilities: ["coding"], registries: ["global"]})
 
       _alpha =
         register_agent!(%{name: "a-cnt", capabilities: ["testing"], registries: ["team-alpha"]})
 
-      {:ok, view, _html_before} = live(conn, ~p"/agents")
+      {:ok, view, _html_before} = live_as_user(conn, user, ~p"/agents")
 
       # Switch to team-alpha — only team-alpha agents shown in list
       html_after = render_hook(view, "select_registry", %{"registry" => "team-alpha"})
@@ -288,7 +316,8 @@ defmodule VicheWeb.AgentsLiveTest do
 
     test "switching registries re-subscribes PubSub — agent_joined broadcast refreshes registries",
          %{
-           conn: conn
+           conn: conn,
+           user: user
          } do
       _global =
         register_agent!(%{name: "pubsub-g", capabilities: ["coding"], registries: ["global"]})
@@ -302,7 +331,7 @@ defmodule VicheWeb.AgentsLiveTest do
           registries: ["team-alpha"]
         })
 
-      {:ok, view, _html} = live(conn, ~p"/agents")
+      {:ok, view, _html} = live_as_user(conn, user, ~p"/agents")
 
       # Switch to team-alpha
       render_hook(view, "select_registry", %{"registry" => "team-alpha"})

--- a/test/viche_web/live/network_live_test.exs
+++ b/test/viche_web/live/network_live_test.exs
@@ -2,6 +2,19 @@ defmodule VicheWeb.NetworkLiveTest do
   use VicheWeb.ConnCase, async: false
   import Phoenix.LiveViewTest
 
+  defp setup_user(_context \\ %{}) do
+    {:ok, user} =
+      Viche.Accounts.create_user(%{email: "network-test-#{System.unique_integer()}@example.com"})
+
+    {:ok, user: user}
+  end
+
+  defp live_as_user(conn, user, path) do
+    conn
+    |> init_test_session(%{"user_id" => user.id})
+    |> live(path)
+  end
+
   defp register_agent!(attrs) do
     {:ok, agent} = Viche.Agents.register_agent(attrs)
     agent
@@ -38,7 +51,12 @@ defmodule VicheWeb.NetworkLiveTest do
   end
 
   describe "URL param — ?registry=" do
-    test "?registry=team-alpha filters network view to team-alpha agents only", %{conn: conn} do
+    setup :setup_user
+
+    test "?registry=team-alpha filters network view to team-alpha agents only", %{
+      conn: conn,
+      user: user
+    } do
       _global =
         register_agent!(%{
           name: "net-url-global",
@@ -53,13 +71,13 @@ defmodule VicheWeb.NetworkLiveTest do
           registries: ["team-alpha"]
         })
 
-      {:ok, _view, html} = live(conn, ~p"/network?registry=team-alpha")
+      {:ok, _view, html} = live_as_user(conn, user, ~p"/network?registry=team-alpha")
 
       refute html =~ "net-url-global"
       assert html =~ "net-url-alpha"
     end
 
-    test "unknown ?registry= param defaults to global agents", %{conn: conn} do
+    test "unknown ?registry= param defaults to global agents", %{conn: conn, user: user} do
       _global =
         register_agent!(%{
           name: "net-def-global",
@@ -67,7 +85,7 @@ defmodule VicheWeb.NetworkLiveTest do
           registries: ["global"]
         })
 
-      {:ok, _view, html} = live(conn, ~p"/network?registry=nonexistent-xyz")
+      {:ok, _view, html} = live_as_user(conn, user, ~p"/network?registry=nonexistent-xyz")
 
       assert html =~ "net-def-global"
     end
@@ -162,7 +180,9 @@ defmodule VicheWeb.NetworkLiveTest do
   end
 
   describe "handle_event select_registry" do
-    test "switching registry updates the agent roster display", %{conn: conn} do
+    setup :setup_user
+
+    test "switching registry updates the agent roster display", %{conn: conn, user: user} do
       _global =
         register_agent!(%{
           name: "net-chg-global",
@@ -177,7 +197,7 @@ defmodule VicheWeb.NetworkLiveTest do
           registries: ["team-alpha"]
         })
 
-      {:ok, view, html} = live(conn, ~p"/network")
+      {:ok, view, html} = live_as_user(conn, user, ~p"/network")
       assert html =~ "net-chg-global"
       refute html =~ "net-chg-alpha"
 
@@ -187,7 +207,10 @@ defmodule VicheWeb.NetworkLiveTest do
       assert html_after =~ "net-chg-alpha"
     end
 
-    test "switching to :all shows agents from all registries in the roster", %{conn: conn} do
+    test "switching to :all shows agents from all registries in the roster", %{
+      conn: conn,
+      user: user
+    } do
       _global =
         register_agent!(%{
           name: "net-all-global",
@@ -202,7 +225,7 @@ defmodule VicheWeb.NetworkLiveTest do
           registries: ["team-alpha"]
         })
 
-      {:ok, view, _html} = live(conn, ~p"/network")
+      {:ok, view, _html} = live_as_user(conn, user, ~p"/network")
 
       html_all = render_hook(view, "select_registry", %{"registry" => "all"})
 
@@ -210,7 +233,10 @@ defmodule VicheWeb.NetworkLiveTest do
       assert html_all =~ "net-all-alpha"
     end
 
-    test "registry filter new_agent broadcast re-subscribes and refreshes roster", %{conn: conn} do
+    test "registry filter new_agent broadcast re-subscribes and refreshes roster", %{
+      conn: conn,
+      user: user
+    } do
       _global =
         register_agent!(%{
           name: "net-pubsub-g",
@@ -227,7 +253,7 @@ defmodule VicheWeb.NetworkLiveTest do
           registries: ["team-alpha"]
         })
 
-      {:ok, view, _html} = live(conn, ~p"/network")
+      {:ok, view, _html} = live_as_user(conn, user, ~p"/network")
 
       # Switch to team-alpha
       render_hook(view, "select_registry", %{"registry" => "team-alpha"})

--- a/test/viche_web/live/sessions_live_test.exs
+++ b/test/viche_web/live/sessions_live_test.exs
@@ -2,6 +2,21 @@ defmodule VicheWeb.SessionsLiveTest do
   use VicheWeb.ConnCase, async: false
   import Phoenix.LiveViewTest
 
+  defp setup_user(_context \\ %{}) do
+    {:ok, user} =
+      Viche.Accounts.create_user(%{
+        email: "sessions-test-#{System.unique_integer()}@example.com"
+      })
+
+    {:ok, user: user}
+  end
+
+  defp live_as_user(conn, user, path) do
+    conn
+    |> init_test_session(%{"user_id" => user.id})
+    |> live(path)
+  end
+
   defp register_agent!(attrs) do
     {:ok, agent} = Viche.Agents.register_agent(attrs)
     agent
@@ -31,7 +46,9 @@ defmodule VicheWeb.SessionsLiveTest do
   end
 
   describe "URL param — ?registry=" do
-    test "default registry shows only global agent inboxes", %{conn: conn} do
+    setup :setup_user
+
+    test "default registry shows only global agent inboxes", %{conn: conn, user: user} do
       global_agent =
         register_agent!(%{
           name: "ses-global-bot",
@@ -49,13 +66,13 @@ defmodule VicheWeb.SessionsLiveTest do
       send_message_to!(global_agent)
       send_message_to!(alpha_agent)
 
-      {:ok, _view, html} = live(conn, ~p"/sessions")
+      {:ok, _view, html} = live_as_user(conn, user, ~p"/sessions")
 
       assert html =~ "ses-global-bot"
       refute html =~ "ses-alpha-bot"
     end
 
-    test "?registry=team-alpha shows only team-alpha agent inboxes", %{conn: conn} do
+    test "?registry=team-alpha shows only team-alpha agent inboxes", %{conn: conn, user: user} do
       global_agent =
         register_agent!(%{
           name: "ses-url-global",
@@ -73,13 +90,13 @@ defmodule VicheWeb.SessionsLiveTest do
       send_message_to!(global_agent)
       send_message_to!(alpha_agent)
 
-      {:ok, _view, html} = live(conn, ~p"/sessions?registry=team-alpha")
+      {:ok, _view, html} = live_as_user(conn, user, ~p"/sessions?registry=team-alpha")
 
       refute html =~ "ses-url-global"
       assert html =~ "ses-url-alpha"
     end
 
-    test "unknown ?registry= param defaults to global agent inboxes", %{conn: conn} do
+    test "unknown ?registry= param defaults to global agent inboxes", %{conn: conn, user: user} do
       global_agent =
         register_agent!(%{
           name: "ses-def-global",
@@ -89,7 +106,7 @@ defmodule VicheWeb.SessionsLiveTest do
 
       send_message_to!(global_agent)
 
-      {:ok, _view, html} = live(conn, ~p"/sessions?registry=nonexistent-xyz")
+      {:ok, _view, html} = live_as_user(conn, user, ~p"/sessions?registry=nonexistent-xyz")
 
       assert html =~ "ses-def-global"
     end
@@ -196,7 +213,9 @@ defmodule VicheWeb.SessionsLiveTest do
   end
 
   describe "handle_event select_registry" do
-    test "switching registry updates inbox display", %{conn: conn} do
+    setup :setup_user
+
+    test "switching registry updates inbox display", %{conn: conn, user: user} do
       global_agent =
         register_agent!(%{
           name: "ses-chg-global",
@@ -214,7 +233,7 @@ defmodule VicheWeb.SessionsLiveTest do
       send_message_to!(global_agent)
       send_message_to!(alpha_agent)
 
-      {:ok, view, html} = live(conn, ~p"/sessions")
+      {:ok, view, html} = live_as_user(conn, user, ~p"/sessions")
       assert html =~ "ses-chg-global"
       refute html =~ "ses-chg-alpha"
 
@@ -224,7 +243,7 @@ defmodule VicheWeb.SessionsLiveTest do
       assert html_after =~ "ses-chg-alpha"
     end
 
-    test "switching to :all shows inboxes from all registries", %{conn: conn} do
+    test "switching to :all shows inboxes from all registries", %{conn: conn, user: user} do
       global_agent =
         register_agent!(%{
           name: "ses-all-global",
@@ -242,7 +261,7 @@ defmodule VicheWeb.SessionsLiveTest do
       send_message_to!(global_agent)
       send_message_to!(alpha_agent)
 
-      {:ok, view, _html} = live(conn, ~p"/sessions")
+      {:ok, view, _html} = live_as_user(conn, user, ~p"/sessions")
 
       html_all = render_hook(view, "select_registry", %{"registry" => "all"})
 
@@ -250,7 +269,7 @@ defmodule VicheWeb.SessionsLiveTest do
       assert html_all =~ "ses-all-alpha"
     end
 
-    test "agent without inbox messages does not appear in inbox list", %{conn: conn} do
+    test "agent without inbox messages does not appear in inbox list", %{conn: conn, user: user} do
       _silent_agent =
         register_agent!(%{
           name: "ses-silent-global",
@@ -258,7 +277,7 @@ defmodule VicheWeb.SessionsLiveTest do
           registries: ["global"]
         })
 
-      {:ok, _view, html} = live(conn, ~p"/sessions")
+      {:ok, _view, html} = live_as_user(conn, user, ~p"/sessions")
 
       # Agent with no messages does not appear in the inbox panel
       refute html =~ "ses-silent-global"


### PR DESCRIPTION
## Description

The registry dropdown was invisible on production due to three compounding issues:

1. **`public_mode` defaulted to `true` in production** (`config/runtime.exs`) — the expression `System.get_env("VICHE_PUBLIC_MODE") not in ~w(false 0)` evaluates to `true` when the env var is unset, which hides the registry selector for all users including authenticated ones.
2. **`/dashboard` required authentication** — unauthenticated visitors were redirected to `/auth/login` and could never see the dashboard or its registry dropdown.
3. **Private registry names leaked to unauthenticated users** — `visible_registries/2` included agent-registered registries for `nil` user IDs, exposing other users' private registry names in the dropdown.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] `mix test`
- [x] `mix credo --strict`
- [x] `mix format --check-formatted`

All 523 tests pass. Updated 4 test files (agents, network, agent_detail, sessions) to use authenticated sessions for registry-switching tests, matching the new behavior that only authenticated users can switch between registries.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes